### PR TITLE
Do not close pipe fildes before duplicating them

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -150,8 +150,7 @@ int _StartModuleProcess(pam_handle_t *pamh, int flags, int argc, const char **ar
             }
             goto done;
         }
-        close(pfd[0]);
-        close(opfd[1]);
+
         child_pid = fork();
         if (child_pid == 0) {
                 // Start child process


### PR DESCRIPTION
This fixes one of the bugs in issue #5. Specifically, closing the pipe file descriptors before calling `dup2()` was causing the helper program to fail when trying to read the password from the pipe. 